### PR TITLE
Fixed security vulnerabilities/memory leaks/bugs in CryptographyHelper.cs

### DIFF
--- a/DataJuggler.Core.UltimateHelper.Test.Cryptography/CryptographyHelperFixture.cs
+++ b/DataJuggler.Core.UltimateHelper.Test.Cryptography/CryptographyHelperFixture.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DataJuggler.Core.UltimateHelper.Test.Cryptography
+{
+    [TestClass]
+    public class CryptographyHelperFixture
+    {
+        [TestMethod]
+        public void TestEncryptionDecryption()
+        {
+            var message = "Some string that has a ↈ weird character in it.";
+            var password = "crypto1234";
+
+            var encrypted = CryptographyHelper.EncryptString(message, password);
+            var decrypted = CryptographyHelper.DecryptString(encrypted, password);
+
+            Assert.AreEqual(message, decrypted);
+        }
+    }
+}

--- a/DataJuggler.Core.UltimateHelper.Test.Cryptography/DataJuggler.Core.UltimateHelper.Test.Cryptography.csproj
+++ b/DataJuggler.Core.UltimateHelper.Test.Cryptography/DataJuggler.Core.UltimateHelper.Test.Cryptography.csproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EFFED536-707A-4AD5-A648-5E63CFC6D2EB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>DataJuggler.Core.UltimateHelper.Test.Cryptography</RootNamespace>
+    <AssemblyName>DataJuggler.Core.UltimateHelper.Test.Cryptography</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\UltimateHelperEx\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\UltimateHelperEx\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CryptographyHelperFixture.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UltimateHelperEx\DataJuggler.Core.UltimateHelper.csproj">
+      <Project>{b570d96e-c163-480d-8c89-192ac7cef60a}</Project>
+      <Name>DataJuggler.Core.UltimateHelper</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\UltimateHelperEx\packages\MSTest.TestAdapter.1.3.2\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/DataJuggler.Core.UltimateHelper.Test.Cryptography/Properties/AssemblyInfo.cs
+++ b/DataJuggler.Core.UltimateHelper.Test.Cryptography/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("DataJuggler.Core.UltimateHelper.Test.Cryptography")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DataJuggler.Core.UltimateHelper.Test.Cryptography")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("effed536-707a-4ad5-a648-5e63cfc6d2eb")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/DataJuggler.Core.UltimateHelper.Test.Cryptography/packages.config
+++ b/DataJuggler.Core.UltimateHelper.Test.Cryptography/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net472" />
+</packages>

--- a/UltimateHelperEx/CryptographyHelper.cs
+++ b/UltimateHelperEx/CryptographyHelper.cs
@@ -16,129 +16,65 @@ namespace DataJuggler.Core.UltimateHelper
     /// This object hands all encryption for this application.
     /// </summary>
     public class CryptographyHelper
-	{	
+	{
+        // We can use a fixed pepper for the PBKDF2 salt.
+        private static byte[] _pepper = new byte[] { 0x04, 0xC5, 0x02, 0xF8, 0xD3, 0xD4, 0x23, 0xB9 };
 	
 	    #region Methods
 
             #region EncryptString(string  stringToEncrypt, string password)
             /// <summary>
-			/// Encrypts a strings passed in using Electronic Code Book Cipher
+			/// Encrypts a strings passed in using CBC mode and a moderately decent KDF.  Does not provide integrity.
 			/// </summary>
 			/// <param customerName="stringToEncrypt">String to encrypt</param>
 			/// <param customerName="productPassword">productPassword needed to unlock encrypted string</param>
 			/// <returns>A new string that must have the same productPassword passed in to unlock.</returns>
             public static string EncryptString(string stringToEncrypt, string password)
 			{
-			    // Initial Value
-			    string encryptedString = null;
-
-                try
+                // We can remove the try-catch and handle null strings properly.
+                if (stringToEncrypt == null)
                 {
-                    // Verify String Does Exist
-                    if (!String.IsNullOrEmpty(stringToEncrypt))
+                    throw new ArgumentException("The string to encrypt cannot be null.", nameof(stringToEncrypt));
+                }
+
+                if (String.IsNullOrEmpty(password))
+                {
+                    throw new ArgumentException("The password to use to generate a key cannot be null or empty", nameof(password));
+                }
+
+                // Remember to dispose of types that implement IDisposable - this old code had lots of memory leaks.
+                using (var aes = AesManaged.Create())
+                using (var pbkdf2 = new Rfc2898DeriveBytes(password, _pepper, 32767)) // MD5 is insecure as KDF, we use PBKDF2 instead.
+                using (var rng = new RNGCryptoServiceProvider())
+                {
+                    var key = pbkdf2.GetBytes(32); // Let's use AES-256.
+                    var iv = new byte[16];
+                    rng.GetBytes(iv); // We always create a new, random IV for each operation.
+
+                    var plaintext = Encoding.UTF8.GetBytes(stringToEncrypt); // We use UTF8 - there is literally no reason to use ASCII in 2019.
+
+                    aes.Mode = CipherMode.CBC;
+                    aes.Padding = PaddingMode.PKCS7;
+                    aes.Key = key;
+                    aes.IV = iv;
+
+                    using (var aesTransformer = aes.CreateEncryptor())
                     {
-
-                        TripleDESCryptoServiceProvider des;
-                        MD5CryptoServiceProvider hashmd5;
-                        byte[] pwdhash;
-                        byte[] buff;
-
-                        hashmd5 = new MD5CryptoServiceProvider();
-                        pwdhash = hashmd5.ComputeHash(ASCIIEncoding.ASCII.GetBytes(password));
-                        hashmd5 = null;
-
-                        //implement DES3 encryption
-                        des = new TripleDESCryptoServiceProvider();
-
-                        //the key is the secret productPassword hash.
-                        des.Key = pwdhash;
-
-                        // Electronic Code Book Cipher
-                        des.Mode = CipherMode.ECB; //CBC, CFB
-
-                        // Set Buffer To StringToEncrypt
-                        buff = ASCIIEncoding.ASCII.GetBytes(stringToEncrypt);
-
-                        // Get Encrypted String
-                        encryptedString = Convert.ToBase64String(des.CreateEncryptor().TransformFinalBlock(buff, 0, buff.Length));
+                        var ciphertext = aesTransformer.TransformFinalBlock(plaintext, 0, plaintext.Length);
+                        var ivAndCiphertext = new byte[iv.Length + ciphertext.Length];
+                        Array.Copy(iv, 0, ivAndCiphertext, 0, iv.Length);
+                        Array.Copy(ciphertext, 0, ivAndCiphertext, iv.Length, ciphertext.Length);
+                        return Convert.ToBase64String(ivAndCiphertext);
                     }
                 }
-                catch
-                {   
-                }
-	            	
-				// Return Encrypted String
-				return encryptedString;
-	            
 			}
 			#endregion
 
-            #region EncryptString(string stringToEncrypt)
-            /// <summary>
-            /// Encrypts a strings passed in using Electronic Code Book Cipher
-            /// </summary>
-            /// <param customerName="stringToEncrypt">String to encrypt</param>
-            /// <returns>A new string that must have the same productPassword passed in to unlock.</returns>
+            // Lots of DRY here - just use the method above rather than copy and paste it all...
             public static string EncryptString(string stringToEncrypt)
             {
-                // Initial Value
-                string encryptedString = null;
-
-                // locals
-                TripleDESCryptoServiceProvider des;
-                MD5CryptoServiceProvider hashmd5;
-                byte[] pwdhash;
-                byte[] buff;
-                
-                // authorization code needed to decrypt productPassword.
-                string authorizationCode = "worldclass";
-                
-                try
-                {
-
-                    // Verify String Does Exist and is not null
-                    if (!String.IsNullOrEmpty(stringToEncrypt))
-                    {
-                        // encrypted system productPassword here
-                        string systemPassword = "KKxEmCUlNi6c0s7etwQclA==";
-
-                        // now decrypt productPassword 
-                        string password = CryptographyHelper.DecryptString(systemPassword, authorizationCode);
-                        
-                        // create MD5 Service 
-                        hashmd5 = new MD5CryptoServiceProvider();
-                        
-                        // compute productPassword has
-                        pwdhash = hashmd5.ComputeHash(ASCIIEncoding.ASCII.GetBytes(password));
-                        
-                        // dispose of hashmd5
-                        hashmd5 = null;
-
-                        // implement DES3 encryption
-                        des = new TripleDESCryptoServiceProvider();
-
-                        // the key is the secret productPassword hash.
-                        des.Key = pwdhash;
-
-                        // Electronic Code Book Cipher (CBC, CFB)
-                        des.Mode = CipherMode.ECB; 
-
-                        // Set Buffer To stringToEncrypt
-                        buff = ASCIIEncoding.ASCII.GetBytes(stringToEncrypt);
-
-                        // Get Encrypted String
-                        encryptedString = Convert.ToBase64String(des.CreateEncryptor().TransformFinalBlock(buff, 0, buff.Length));
-                    }
-                }
-                catch
-                {
-                }
-
-                // Return Encrypted String
-                return encryptedString;
-
+                return EncryptString(stringToEncrypt, "worldclass");
             }
-            #endregion
 
             #region DecryptString(string  stringToDecrypt, string password)
             /// <summary>
@@ -149,115 +85,54 @@ namespace DataJuggler.Core.UltimateHelper
 			/// <returns></returns>
             public static string DecryptString(string stringToDecrypt, string password)
 			{
-                // initial value
-			    string decryptedString = null;
-
-                try
+                if (stringToDecrypt == null)
                 {
-                    TripleDESCryptoServiceProvider des;
-                    MD5CryptoServiceProvider hashmd5;
-                    byte[] pwdhash;
-                    byte[] buff;
-
-                    hashmd5 = new MD5CryptoServiceProvider();
-                    pwdhash = hashmd5.ComputeHash(ASCIIEncoding.ASCII.GetBytes(password));
-                    hashmd5 = null;
-
-                    //implement DES3 encryption
-                    des = new TripleDESCryptoServiceProvider();
-
-                    //the key is the secret productPassword hash.
-                    des.Key = pwdhash;
-
-                    // Electronic Code Book Cipher
-                    des.Mode = CipherMode.ECB; //CBC, CFB
-
-                    // Decrypt String
-                    buff = Convert.FromBase64String(stringToDecrypt);
-
-                    //decrypt DES 3 encrypted byte buffer and return ASCII string
-                    decryptedString = ASCIIEncoding.ASCII.GetString(des.CreateDecryptor().TransformFinalBlock(buff, 0, buff.Length));
+                    throw new ArgumentException("The string to decrypt cannot be null.", nameof(stringToDecrypt));
                 }
-                catch 
+
+                if (String.IsNullOrEmpty(password))
                 {
-                    
-                    
+                    throw new ArgumentException("The password to use to generate a key cannot be null or empty", nameof(password));
                 }
-					
-				// Return Value
-				return decryptedString;
-					
-			}
-			#endregion
 
-            #region DecryptString(string  stringToDecrypt)
-            /// <summary>
-            /// Decrypts a string passed in.
-            /// </summary>
-            /// <param customerName="stringToDecrypt">String that needs to be deciphered.</param>
-            /// <returns></returns>
+                var ivAndCiphertext = Convert.FromBase64String(stringToDecrypt);
+                if (ivAndCiphertext.Length < 16)
+                {
+                    throw new ArgumentException("The provided ciphertext is invalid.", nameof(stringToDecrypt));
+                }
+
+                var iv = new byte[16];
+                var ciphertext = new byte[ivAndCiphertext.Length - 16];
+                Array.Copy(ivAndCiphertext, 0, iv, 0, iv.Length);
+                Array.Copy(ivAndCiphertext, iv.Length, ciphertext, 0, ciphertext.Length);
+
+                using (var aes = AesManaged.Create())
+                using (var pbkdf2 = new Rfc2898DeriveBytes(password, _pepper, 32767))
+                {
+                    var key = pbkdf2.GetBytes(32);
+
+                    aes.Mode = CipherMode.CBC;
+                    aes.Padding = PaddingMode.PKCS7;
+                    aes.Key = key;
+                    aes.IV = iv;
+
+                    using (var aesTransformer = aes.CreateDecryptor())
+                    {
+                        var plaintext = aesTransformer.TransformFinalBlock(ciphertext, 0, ciphertext.Length);
+                        return Encoding.UTF8.GetString(plaintext);
+                    }
+                }
+            }
+        #endregion
+
             public static string DecryptString(string stringToDecrypt)
             {
-
-                // initial value
-                string decryptedString = null;
-
-                // locals
-                TripleDESCryptoServiceProvider des;
-                MD5CryptoServiceProvider hashmd5;
-                byte[] pwdhash;
-                byte[] buff;
-
-                // authorization code needed to decrypt productPassword.
-                string authorizationCode = "worldclass";
-
-                try
-                {
-                    // encrypted system productPassword here
-                    string systemPassword = "KKxEmCUlNi6c0s7etwQclA==";
-                    
-                    // now decrypt productPassword 
-                    string password = CryptographyHelper.DecryptString(systemPassword, authorizationCode);
-                
-                    // Create MD5 CryptoServiceProvider
-                    hashmd5 = new MD5CryptoServiceProvider();
-                    
-                    // computer productPassword hash
-                    pwdhash = hashmd5.ComputeHash(ASCIIEncoding.ASCII.GetBytes(password));
-                    
-                    // dispose of object
-                    hashmd5 = null;
-
-                    //implement DES3 encryption
-                    des = new TripleDESCryptoServiceProvider();
-
-                    //the key is the secret productPassword hash.
-                    des.Key = pwdhash;
-
-                    // Electronic Code Book Cipher (CBC, CFB)
-                    des.Mode = CipherMode.ECB; 
-
-                    // Decrypt String
-                    buff = Convert.FromBase64String(stringToDecrypt);
-
-                    //decrypt DES 3 encrypted byte buffer and return ASCII string
-                    decryptedString = ASCIIEncoding.ASCII.GetString(des.CreateDecryptor().TransformFinalBlock(buff, 0, buff.Length));
-                }
-                catch
-                {
-
-
-                }
-
-                // Return Value
-                return decryptedString;
-
+                return DecryptString(stringToDecrypt, "worldclass");
             }
-            #endregion
-			
-		#endregion
-		
-	}
+
+        #endregion
+
+    }
 	#endregion
 
 }

--- a/UltimateHelperEx/DataJuggler.Core.UltimateHelper.csproj
+++ b/UltimateHelperEx/DataJuggler.Core.UltimateHelper.csproj
@@ -40,7 +40,8 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>DataJuggler.Core.UltimateHelper.Ex.pfx</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -87,9 +88,6 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="RAD Studio Icon.ico" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="DataJuggler.Core.UltimateHelper.Ex.pfx" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UltimateHelperEx/DataJuggler.Core.UltimateHelper.sln
+++ b/UltimateHelperEx/DataJuggler.Core.UltimateHelper.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.28922.388
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataJuggler.Core.UltimateHelper", "DataJuggler.Core.UltimateHelper.csproj", "{B570D96E-C163-480D-8C89-192AC7CEF60A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DataJuggler.Core.UltimateHelper.Test.Cryptography", "..\DataJuggler.Core.UltimateHelper.Test.Cryptography\DataJuggler.Core.UltimateHelper.Test.Cryptography.csproj", "{EFFED536-707A-4AD5-A648-5E63CFC6D2EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{B570D96E-C163-480D-8C89-192AC7CEF60A}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{B570D96E-C163-480D-8C89-192AC7CEF60A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B570D96E-C163-480D-8C89-192AC7CEF60A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFFED536-707A-4AD5-A648-5E63CFC6D2EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFFED536-707A-4AD5-A648-5E63CFC6D2EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFFED536-707A-4AD5-A648-5E63CFC6D2EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFFED536-707A-4AD5-A648-5E63CFC6D2EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR addresses a number of the issues raised [on this StackOverflow question](https://stackoverflow.com/questions/59147167/encryption-with-same-parameters-need-different-results/59147850?noredirect=1#comment104549969_59147850) that the author more or less refused to acknowledge or fix.

I've tried to annotate the locations that needed changing.